### PR TITLE
Added temporary Ollama functionality to /api/generate

### DIFF
--- a/bot_backend/Dockerfile
+++ b/bot_backend/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /code
 
 COPY ./requirements.txt /code/requirements.txt
 
+#Following RUN command will be removed in the future as Ollama will be replaced
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -fsSL https://ollama.com/install.sh | sh && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY ./app /code/app

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,6 +4,11 @@ server {
 
     server_name 134.122.115.227;
 
+    # Needs to be reviewed in the future
+    proxy_read_timeout 300;
+    proxy_connect_timeout 300;
+    proxy_send_timeout 300;
+  
     # Serve the frontend from Nginx
     location / {
         root /usr/share/nginx/html;


### PR DESCRIPTION
NOTE: Current setup requires a user to enter the backend container's exec shell and manually run the `ollama serve `and `ollama pull llama3.2' commands, respectively.